### PR TITLE
feat(Exchanger): Add max pending settlement limit

### DIFF
--- a/src/interface/platforms/synths/IExchanger.sol
+++ b/src/interface/platforms/synths/IExchanger.sol
@@ -155,6 +155,7 @@ interface IExchanger is IPlatform {
     error NoSwaps();
     error SettlementDelayNotOver();
     error InsufficientGasFee();
+    error MaxPendingSettlementReached();
 
     event SynthAdded(address indexed synth);
     event SynthRemoved(address indexed synth);

--- a/src/platforms/Synths/Exchanger.sol
+++ b/src/platforms/Synths/Exchanger.sol
@@ -27,6 +27,7 @@ contract Exchanger is IExchanger, UUPSProxy {
     mapping(address => bool) public isSynth;
 
     uint256 public swapNonce;
+    uint256 public constant MAX_PENDING_SETTLEMENT = 10;
 
     /**
      * @notice With each swap the user will receive less synthOut,
@@ -85,6 +86,10 @@ contract Exchanger is IExchanger, UUPSProxy {
         returns (uint256 amountOut)
     {
         if (msg.value != getSwapFeeForSettle()) revert InsufficientGasFee();
+
+        if (_settlements[receiver][synthOut].swaps.length + 1 == MAX_PENDING_SETTLEMENT) {
+            revert MaxPendingSettlementReached();
+        }
 
         amountIn = _chargeFee(synthIn, amountIn, msg.sender);
         amountOut = _previewSwap(synthIn, synthOut, amountIn);

--- a/test/platforms/synths/Exchanger/Exchanger.Swap.sol
+++ b/test/platforms/synths/Exchanger/Exchanger.Swap.sol
@@ -44,4 +44,15 @@ contract ExchangerSwapTest is ExchangerSetup {
         assertGt(feeReceiverBalanceAfter, feeReceiverBalanceBefore);
         assertGt(debtSharesBalanceAfter, debtSharesBalanceBefore);
     }
+
+    function test_swap_maxPendingSettlementReached() public {
+        for (uint256 i = 0; i < exchanger.MAX_PENDING_SETTLEMENT() - 1; i++) {
+            _swap(address(xusd), address(gold), 1e4);
+        }
+
+        uint256 swapFee = exchanger.getSwapFeeForSettle();
+
+        vm.expectRevert(IExchanger.MaxPendingSettlementReached.selector);
+        exchanger.swap{value: swapFee}(address(xusd), address(gold), 1e4, address(this));
+    }
 }


### PR DESCRIPTION
Implement a maximum limit for pending settlements in the Exchanger contract to prevent excessive pending swaps. This includes:
- Adding a MAX_PENDING_SETTLEMENT constant
- Introducing a MaxPendingSettlementReached error
- Checking the number of pending settlements before allowing a new swap
- Adding a corresponding test case to verify the new limit