### PR TITLE
feat(Exchanger): Add synth management with existence check

### DIFF
--- a/src/interface/platforms/synths/IExchanger.sol
+++ b/src/interface/platforms/synths/IExchanger.sol
@@ -121,7 +121,8 @@ interface IExchanger is IPlatform {
     ) external returns (address);
 
     /* ======== Events ======== */
-
+    event SynthAdded(address indexed synth);
+    event SynthRemoved(address indexed synth);
     event FinishSwapDelayChanged(uint256 finishSwapDelay);
     event SwapFeeChanged(uint256 swapFee);
     event FeeReceiverChanged(address feeReceiver);
@@ -160,7 +161,5 @@ interface IExchanger is IPlatform {
     error SettlementDelayNotOver();
     error InsufficientGasFee();
     error MaxPendingSettlementReached();
-
-    event SynthAdded(address indexed synth);
-    event SynthRemoved(address indexed synth);
+    error SynthAlreadyExists();
 }

--- a/src/platforms/Synths/Exchanger.sol
+++ b/src/platforms/Synths/Exchanger.sol
@@ -282,6 +282,8 @@ contract Exchanger is IExchanger, UUPSProxy {
         noZeroAddress(_synth)
         validInterface(_synth, type(ISynth).interfaceId)
     {
+        if (isSynth[_synth]) revert SynthAlreadyExists();
+
         isSynth[_synth] = true;
         _synths.push(_synth);
         emit SynthAdded(_synth);

--- a/test/platforms/synths/Exchanger/Exchanger.Admin.sol
+++ b/test/platforms/synths/Exchanger/Exchanger.Admin.sol
@@ -8,30 +8,49 @@ contract ExchangerAdminTest is ExchangerSetup {
     address newAddress = address(0x52);
 
     function test_setSwapFee() public {
-        vm.expectEmit(true, true, true, true);
+        vm.expectEmit();
         emit IExchanger.SwapFeeChanged(newUint);
         exchanger.setSwapFee(newUint);
         assertEq(exchanger.swapFee(), newUint);
     }
 
     function test_setFeeReceiver() public {
-        vm.expectEmit(true, true, true, true);
+        vm.expectEmit();
         emit IExchanger.FeeReceiverChanged(newAddress);
         exchanger.setFeeReceiver(newAddress);
         assertEq(exchanger.feeReceiver(), newAddress);
     }
 
     function test_setSettlementDelay() public {
-        vm.expectEmit(true, true, true, true);
+        vm.expectEmit();
         emit IExchanger.FinishSwapDelayChanged(newUint);
         exchanger.setFinishSwapDelay(newUint);
         assertEq(exchanger.finishSwapDelay(), newUint);
     }
 
     function test_setBurntAtSwap() public {
-        vm.expectEmit(true, true, true, true);
+        vm.expectEmit();
         emit IExchanger.BurntAtSwapChanged(newUint);
         exchanger.setBurntAtSwap(newUint);
         assertEq(exchanger.burntAtSwap(), newUint);
+    }
+
+    function test_addNewSynth() public {
+        vm.expectEmit(false, false, false, false);
+        emit IExchanger.SynthAdded(address(0));
+        address synth = exchanger.createSynth(address(new Synth()), address(this), "Test", "TST");
+        assertEq(exchanger.isSynth(synth), true);
+    }
+
+    function test_addNewSynth_revertIfSynthAlreadyExists() public {
+        vm.expectRevert(IExchanger.SynthAlreadyExists.selector);
+        exchanger.addNewSynth(address(xusd));
+    }
+
+    function test_removeSynth() public {
+        vm.expectEmit();
+        emit IExchanger.SynthRemoved(address(xusd));
+        exchanger.removeSynth(address(xusd));
+        assertEq(exchanger.isSynth(address(xusd)), false);
     }
 }


### PR DESCRIPTION
- Introduce SynthAlreadyExists error to prevent duplicate synths
- Update addNewSynth method to validate synth uniqueness
- Add test cases for adding and removing synths
- Reorganize synth-related events in IExchanger interface